### PR TITLE
feat: Bicep IaC skeleton for App Service, SQL, and Key Vault (#5)

### DIFF
--- a/infra/bicep/environments/prod/prod.bicepparam
+++ b/infra/bicep/environments/prod/prod.bicepparam
@@ -1,0 +1,14 @@
+using '../../main.bicep'
+
+param location = 'eastus'
+param appServicePlanName = 'plan-exam-simulator-prd'
+param appName = 'app-exam-simulator-prd'
+param sqlServerName = 'sql-exam-simulator-prd'
+param sqlDatabaseName = 'ExamSimulator'
+param keyVaultName = 'kv-exam-sim-prd'
+param adminLogin = readEnvironmentVariable('SQL_ADMIN_LOGIN', '')
+param adminPassword = readEnvironmentVariable('SQL_ADMIN_PASSWORD', '')
+param appServiceSkuName = 'B1'
+param appServiceSkuTier = 'Basic'
+param sqlDatabaseSkuName = 'Basic'
+param sqlDatabaseSkuTier = 'Basic'

--- a/infra/bicep/environments/staging/staging.bicepparam
+++ b/infra/bicep/environments/staging/staging.bicepparam
@@ -1,0 +1,14 @@
+using '../../main.bicep'
+
+param location = 'eastus'
+param appServicePlanName = 'plan-exam-simulator-stg'
+param appName = 'app-exam-simulator-stg'
+param sqlServerName = 'sql-exam-simulator-stg'
+param sqlDatabaseName = 'ExamSimulator'
+param keyVaultName = 'kv-exam-sim-stg'
+param adminLogin = readEnvironmentVariable('SQL_ADMIN_LOGIN', '')
+param adminPassword = readEnvironmentVariable('SQL_ADMIN_PASSWORD', '')
+param appServiceSkuName = 'F1'
+param appServiceSkuTier = 'Free'
+param sqlDatabaseSkuName = 'Basic'
+param sqlDatabaseSkuTier = 'Basic'

--- a/infra/bicep/main.bicep
+++ b/infra/bicep/main.bicep
@@ -1,0 +1,73 @@
+@description('Azure region for all resources.')
+param location string = resourceGroup().location
+
+@description('Name of the App Service Plan.')
+param appServicePlanName string
+
+@description('Name of the Web App.')
+param appName string
+
+@description('Name of the Azure SQL logical server.')
+param sqlServerName string
+
+@description('Name of the SQL database.')
+param sqlDatabaseName string
+
+@description('Name of the Key Vault.')
+param keyVaultName string
+
+@description('SQL Server administrator login name.')
+param adminLogin string
+
+@description('SQL Server administrator login password.')
+@secure()
+param adminPassword string
+
+@description('App Service Plan SKU name.')
+param appServiceSkuName string = 'S1'
+
+@description('App Service Plan SKU tier.')
+param appServiceSkuTier string = 'Standard'
+
+@description('SQL database SKU name.')
+param sqlDatabaseSkuName string = 'S0'
+
+@description('SQL database SKU tier.')
+param sqlDatabaseSkuTier string = 'Standard'
+
+module appSvc 'modules/appservice.bicep' = {
+  params: {
+    planName: appServicePlanName
+    appName: appName
+    location: location
+    skuName: appServiceSkuName
+    skuTier: appServiceSkuTier
+    keyVaultName: keyVaultName
+  }
+}
+
+module sql 'modules/sql.bicep' = {
+  params: {
+    serverName: sqlServerName
+    databaseName: sqlDatabaseName
+    location: location
+    adminLogin: adminLogin
+    adminPassword: adminPassword
+    databaseSkuName: sqlDatabaseSkuName
+    databaseSkuTier: sqlDatabaseSkuTier
+  }
+}
+
+// Key Vault depends on both modules: needs the App Service principal ID and the SQL connection string
+module kv 'modules/keyvault.bicep' = {
+  params: {
+    name: keyVaultName
+    location: location
+    appServicePrincipalId: appSvc.outputs.principalId
+    sqlConnectionString: sql.outputs.connectionString
+  }
+}
+
+output appUrl string = 'https://${appSvc.outputs.hostname}'
+output sqlServerFqdn string = sql.outputs.serverFqdn
+output keyVaultUri string = kv.outputs.vaultUri

--- a/infra/bicep/main.json
+++ b/infra/bicep/main.json
@@ -1,0 +1,500 @@
+{
+  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+  "languageVersion": "2.0",
+  "contentVersion": "1.0.0.0",
+  "metadata": {
+    "_generator": {
+      "name": "bicep",
+      "version": "0.40.2.10011",
+      "templateHash": "9789807879452377197"
+    }
+  },
+  "parameters": {
+    "location": {
+      "type": "string",
+      "defaultValue": "[resourceGroup().location]",
+      "metadata": {
+        "description": "Azure region for all resources."
+      }
+    },
+    "appServicePlanName": {
+      "type": "string",
+      "metadata": {
+        "description": "Name of the App Service Plan."
+      }
+    },
+    "appName": {
+      "type": "string",
+      "metadata": {
+        "description": "Name of the Web App."
+      }
+    },
+    "sqlServerName": {
+      "type": "string",
+      "metadata": {
+        "description": "Name of the Azure SQL logical server."
+      }
+    },
+    "sqlDatabaseName": {
+      "type": "string",
+      "metadata": {
+        "description": "Name of the SQL database."
+      }
+    },
+    "keyVaultName": {
+      "type": "string",
+      "metadata": {
+        "description": "Name of the Key Vault."
+      }
+    },
+    "adminLogin": {
+      "type": "string",
+      "metadata": {
+        "description": "SQL Server administrator login name."
+      }
+    },
+    "adminPassword": {
+      "type": "securestring",
+      "metadata": {
+        "description": "SQL Server administrator login password."
+      }
+    },
+    "appServiceSkuName": {
+      "type": "string",
+      "defaultValue": "S1",
+      "metadata": {
+        "description": "App Service Plan SKU name."
+      }
+    },
+    "appServiceSkuTier": {
+      "type": "string",
+      "defaultValue": "Standard",
+      "metadata": {
+        "description": "App Service Plan SKU tier."
+      }
+    },
+    "sqlDatabaseSkuName": {
+      "type": "string",
+      "defaultValue": "S0",
+      "metadata": {
+        "description": "SQL database SKU name."
+      }
+    },
+    "sqlDatabaseSkuTier": {
+      "type": "string",
+      "defaultValue": "Standard",
+      "metadata": {
+        "description": "SQL database SKU tier."
+      }
+    }
+  },
+  "resources": {
+    "appSvc": {
+      "type": "Microsoft.Resources/deployments",
+      "apiVersion": "2025-04-01",
+      "name": "[format('appSvc-{0}', uniqueString('appSvc', deployment().name))]",
+      "properties": {
+        "expressionEvaluationOptions": {
+          "scope": "inner"
+        },
+        "mode": "Incremental",
+        "parameters": {
+          "planName": {
+            "value": "[parameters('appServicePlanName')]"
+          },
+          "appName": {
+            "value": "[parameters('appName')]"
+          },
+          "location": {
+            "value": "[parameters('location')]"
+          },
+          "skuName": {
+            "value": "[parameters('appServiceSkuName')]"
+          },
+          "skuTier": {
+            "value": "[parameters('appServiceSkuTier')]"
+          },
+          "keyVaultName": {
+            "value": "[parameters('keyVaultName')]"
+          }
+        },
+        "template": {
+          "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+          "contentVersion": "1.0.0.0",
+          "metadata": {
+            "_generator": {
+              "name": "bicep",
+              "version": "0.40.2.10011",
+              "templateHash": "1663591395173764225"
+            }
+          },
+          "parameters": {
+            "planName": {
+              "type": "string",
+              "metadata": {
+                "description": "Name of the App Service Plan."
+              }
+            },
+            "appName": {
+              "type": "string",
+              "metadata": {
+                "description": "Name of the Web App."
+              }
+            },
+            "location": {
+              "type": "string"
+            },
+            "skuName": {
+              "type": "string",
+              "defaultValue": "S1",
+              "metadata": {
+                "description": "App Service Plan SKU name, e.g. S1, B1."
+              }
+            },
+            "skuTier": {
+              "type": "string",
+              "defaultValue": "Standard",
+              "metadata": {
+                "description": "App Service Plan SKU tier, e.g. Standard, Basic."
+              }
+            },
+            "keyVaultName": {
+              "type": "string",
+              "metadata": {
+                "description": "Name of the Key Vault holding the connection string secret."
+              }
+            },
+            "connectionStringSecretName": {
+              "type": "string",
+              "defaultValue": "ConnectionStrings--DefaultConnection",
+              "metadata": {
+                "description": "Name of the Key Vault secret containing the database connection string."
+              }
+            }
+          },
+          "resources": [
+            {
+              "type": "Microsoft.Web/serverfarms",
+              "apiVersion": "2023-12-01",
+              "name": "[parameters('planName')]",
+              "location": "[parameters('location')]",
+              "sku": {
+                "name": "[parameters('skuName')]",
+                "tier": "[parameters('skuTier')]"
+              },
+              "kind": "linux",
+              "properties": {
+                "reserved": true
+              }
+            },
+            {
+              "type": "Microsoft.Web/sites",
+              "apiVersion": "2023-12-01",
+              "name": "[parameters('appName')]",
+              "location": "[parameters('location')]",
+              "identity": {
+                "type": "SystemAssigned"
+              },
+              "properties": {
+                "serverFarmId": "[resourceId('Microsoft.Web/serverfarms', parameters('planName'))]",
+                "httpsOnly": true,
+                "siteConfig": {
+                  "linuxFxVersion": "DOTNETCORE|10.0",
+                  "minTlsVersion": "1.2",
+                  "connectionStrings": [
+                    {
+                      "name": "DefaultConnection",
+                      "connectionString": "[format('@Microsoft.KeyVault(VaultName={0};SecretName={1})', parameters('keyVaultName'), parameters('connectionStringSecretName'))]",
+                      "type": "SQLAzure"
+                    }
+                  ]
+                }
+              },
+              "dependsOn": [
+                "[resourceId('Microsoft.Web/serverfarms', parameters('planName'))]"
+              ]
+            }
+          ],
+          "outputs": {
+            "principalId": {
+              "type": "string",
+              "value": "[reference(resourceId('Microsoft.Web/sites', parameters('appName')), '2023-12-01', 'full').identity.principalId]"
+            },
+            "hostname": {
+              "type": "string",
+              "value": "[reference(resourceId('Microsoft.Web/sites', parameters('appName')), '2023-12-01').defaultHostName]"
+            }
+          }
+        }
+      }
+    },
+    "sql": {
+      "type": "Microsoft.Resources/deployments",
+      "apiVersion": "2025-04-01",
+      "name": "[format('sql-{0}', uniqueString('sql', deployment().name))]",
+      "properties": {
+        "expressionEvaluationOptions": {
+          "scope": "inner"
+        },
+        "mode": "Incremental",
+        "parameters": {
+          "serverName": {
+            "value": "[parameters('sqlServerName')]"
+          },
+          "databaseName": {
+            "value": "[parameters('sqlDatabaseName')]"
+          },
+          "location": {
+            "value": "[parameters('location')]"
+          },
+          "adminLogin": {
+            "value": "[parameters('adminLogin')]"
+          },
+          "adminPassword": {
+            "value": "[parameters('adminPassword')]"
+          },
+          "databaseSkuName": {
+            "value": "[parameters('sqlDatabaseSkuName')]"
+          },
+          "databaseSkuTier": {
+            "value": "[parameters('sqlDatabaseSkuTier')]"
+          }
+        },
+        "template": {
+          "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+          "languageVersion": "2.0",
+          "contentVersion": "1.0.0.0",
+          "metadata": {
+            "_generator": {
+              "name": "bicep",
+              "version": "0.40.2.10011",
+              "templateHash": "1661658632256610353"
+            }
+          },
+          "parameters": {
+            "serverName": {
+              "type": "string",
+              "metadata": {
+                "description": "Name of the Azure SQL logical server."
+              }
+            },
+            "databaseName": {
+              "type": "string",
+              "metadata": {
+                "description": "Name of the database."
+              }
+            },
+            "location": {
+              "type": "string"
+            },
+            "adminLogin": {
+              "type": "string",
+              "metadata": {
+                "description": "SQL Server administrator login name."
+              }
+            },
+            "adminPassword": {
+              "type": "securestring",
+              "metadata": {
+                "description": "SQL Server administrator login password."
+              }
+            },
+            "databaseSkuName": {
+              "type": "string",
+              "defaultValue": "S0",
+              "metadata": {
+                "description": "Database SKU name, e.g. S0, S1."
+              }
+            },
+            "databaseSkuTier": {
+              "type": "string",
+              "defaultValue": "Standard",
+              "metadata": {
+                "description": "Database SKU tier."
+              }
+            }
+          },
+          "resources": {
+            "sqlServer": {
+              "type": "Microsoft.Sql/servers",
+              "apiVersion": "2023-08-01-preview",
+              "name": "[parameters('serverName')]",
+              "location": "[parameters('location')]",
+              "properties": {
+                "administratorLogin": "[parameters('adminLogin')]",
+                "administratorLoginPassword": "[parameters('adminPassword')]",
+                "minimalTlsVersion": "1.2",
+                "publicNetworkAccess": "Enabled"
+              }
+            },
+            "allowAzureServices": {
+              "type": "Microsoft.Sql/servers/firewallRules",
+              "apiVersion": "2023-08-01-preview",
+              "name": "[format('{0}/{1}', parameters('serverName'), 'AllowAllWindowsAzureIps')]",
+              "properties": {
+                "startIpAddress": "0.0.0.0",
+                "endIpAddress": "0.0.0.0"
+              },
+              "dependsOn": [
+                "sqlServer"
+              ]
+            },
+            "sqlDatabase": {
+              "type": "Microsoft.Sql/servers/databases",
+              "apiVersion": "2023-08-01-preview",
+              "name": "[format('{0}/{1}', parameters('serverName'), parameters('databaseName'))]",
+              "location": "[parameters('location')]",
+              "sku": {
+                "name": "[parameters('databaseSkuName')]",
+                "tier": "[parameters('databaseSkuTier')]"
+              },
+              "dependsOn": [
+                "sqlServer"
+              ]
+            }
+          },
+          "outputs": {
+            "serverFqdn": {
+              "type": "string",
+              "value": "[reference('sqlServer').fullyQualifiedDomainName]"
+            },
+            "connectionString": {
+              "type": "securestring",
+              "value": "[format('Server=tcp:{0},1433;Database={1};User Id={2};Password={3};Encrypt=True;TrustServerCertificate=False;Connection Timeout=30;', reference('sqlServer').fullyQualifiedDomainName, parameters('databaseName'), parameters('adminLogin'), parameters('adminPassword'))]"
+            }
+          }
+        }
+      }
+    },
+    "kv": {
+      "type": "Microsoft.Resources/deployments",
+      "apiVersion": "2025-04-01",
+      "name": "[format('kv-{0}', uniqueString('kv', deployment().name))]",
+      "properties": {
+        "expressionEvaluationOptions": {
+          "scope": "inner"
+        },
+        "mode": "Incremental",
+        "parameters": {
+          "name": {
+            "value": "[parameters('keyVaultName')]"
+          },
+          "location": {
+            "value": "[parameters('location')]"
+          },
+          "appServicePrincipalId": {
+            "value": "[reference('appSvc').outputs.principalId.value]"
+          },
+          "sqlConnectionString": {
+            "value": "[listOutputsWithSecureValues('sql', '2025-04-01').connectionString]"
+          }
+        },
+        "template": {
+          "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+          "contentVersion": "1.0.0.0",
+          "metadata": {
+            "_generator": {
+              "name": "bicep",
+              "version": "0.40.2.10011",
+              "templateHash": "17327882541618625085"
+            }
+          },
+          "parameters": {
+            "name": {
+              "type": "string",
+              "metadata": {
+                "description": "Name of the Key Vault. Must be 3–24 alphanumeric characters or hyphens."
+              }
+            },
+            "location": {
+              "type": "string"
+            },
+            "appServicePrincipalId": {
+              "type": "string",
+              "metadata": {
+                "description": "Principal ID of the App Service system-assigned managed identity."
+              }
+            },
+            "sqlConnectionString": {
+              "type": "securestring",
+              "metadata": {
+                "description": "Full SQL connection string to store as a secret."
+              }
+            }
+          },
+          "variables": {
+            "kvSecretsUserRoleId": "4633458b-17de-408a-b874-0445c86b69e0",
+            "connectionStringSecretName": "ConnectionStrings--DefaultConnection"
+          },
+          "resources": [
+            {
+              "type": "Microsoft.KeyVault/vaults",
+              "apiVersion": "2023-07-01",
+              "name": "[parameters('name')]",
+              "location": "[parameters('location')]",
+              "properties": {
+                "tenantId": "[tenant().tenantId]",
+                "sku": {
+                  "family": "A",
+                  "name": "standard"
+                },
+                "enableRbacAuthorization": true,
+                "enableSoftDelete": true,
+                "softDeleteRetentionInDays": 7
+              }
+            },
+            {
+              "type": "Microsoft.KeyVault/vaults/secrets",
+              "apiVersion": "2023-07-01",
+              "name": "[format('{0}/{1}', parameters('name'), variables('connectionStringSecretName'))]",
+              "properties": {
+                "value": "[parameters('sqlConnectionString')]"
+              },
+              "dependsOn": [
+                "[resourceId('Microsoft.KeyVault/vaults', parameters('name'))]"
+              ]
+            },
+            {
+              "type": "Microsoft.Authorization/roleAssignments",
+              "apiVersion": "2022-04-01",
+              "scope": "[resourceId('Microsoft.KeyVault/vaults', parameters('name'))]",
+              "name": "[guid(resourceId('Microsoft.KeyVault/vaults', parameters('name')), parameters('appServicePrincipalId'), variables('kvSecretsUserRoleId'))]",
+              "properties": {
+                "roleDefinitionId": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', variables('kvSecretsUserRoleId'))]",
+                "principalId": "[parameters('appServicePrincipalId')]",
+                "principalType": "ServicePrincipal"
+              },
+              "dependsOn": [
+                "[resourceId('Microsoft.KeyVault/vaults', parameters('name'))]"
+              ]
+            }
+          ],
+          "outputs": {
+            "vaultUri": {
+              "type": "string",
+              "value": "[reference(resourceId('Microsoft.KeyVault/vaults', parameters('name')), '2023-07-01').vaultUri]"
+            }
+          }
+        }
+      },
+      "dependsOn": [
+        "appSvc",
+        "sql"
+      ]
+    }
+  },
+  "outputs": {
+    "appUrl": {
+      "type": "string",
+      "value": "[format('https://{0}', reference('appSvc').outputs.hostname.value)]"
+    },
+    "sqlServerFqdn": {
+      "type": "string",
+      "value": "[reference('sql').outputs.serverFqdn.value]"
+    },
+    "keyVaultUri": {
+      "type": "string",
+      "value": "[reference('kv').outputs.vaultUri.value]"
+    }
+  }
+}

--- a/infra/bicep/modules/appservice.bicep
+++ b/infra/bicep/modules/appservice.bicep
@@ -1,0 +1,58 @@
+@description('Name of the App Service Plan.')
+param planName string
+
+@description('Name of the Web App.')
+param appName string
+
+param location string
+
+@description('App Service Plan SKU name, e.g. S1, B1.')
+param skuName string = 'B1'
+
+@description('App Service Plan SKU tier, e.g. Standard, Basic.')
+param skuTier string = 'Basic'
+
+@description('Name of the Key Vault holding the connection string secret.')
+param keyVaultName string
+
+@description('Name of the Key Vault secret containing the database connection string.')
+param connectionStringSecretName string = 'ConnectionStrings--DefaultConnection'
+
+resource plan 'Microsoft.Web/serverFarms@2023-12-01' = {
+  name: planName
+  location: location
+  sku: {
+    name: skuName
+    tier: skuTier
+  }
+  kind: 'linux'
+  properties: {
+    reserved: true
+  }
+}
+
+resource app 'Microsoft.Web/sites@2023-12-01' = {
+  name: appName
+  location: location
+  identity: {
+    type: 'SystemAssigned'
+  }
+  properties: {
+    serverFarmId: plan.id
+    httpsOnly: true
+    siteConfig: {
+      linuxFxVersion: 'DOTNETCORE|10.0'
+      minTlsVersion: '1.2'
+      connectionStrings: [
+        {
+          name: 'DefaultConnection'
+          connectionString: '@Microsoft.KeyVault(VaultName=${keyVaultName};SecretName=${connectionStringSecretName})'
+          type: 'SQLAzure'
+        }
+      ]
+    }
+  }
+}
+
+output principalId string = app.identity.principalId
+output hostname string = app.properties.defaultHostName

--- a/infra/bicep/modules/keyvault.bicep
+++ b/infra/bicep/modules/keyvault.bicep
@@ -1,0 +1,51 @@
+@description('Name of the Key Vault. Must be 3–24 alphanumeric characters or hyphens.')
+param name string
+
+param location string
+
+@description('Principal ID of the App Service system-assigned managed identity.')
+param appServicePrincipalId string
+
+@description('Full SQL connection string to store as a secret.')
+@secure()
+param sqlConnectionString string
+
+// Key Vault Secrets User built-in role
+var kvSecretsUserRoleId = '4633458b-17de-408a-b874-0445c86b69e0'
+var connectionStringSecretName = 'ConnectionStrings--DefaultConnection'
+
+resource kv 'Microsoft.KeyVault/vaults@2023-07-01' = {
+  name: name
+  location: location
+  properties: {
+    tenantId: tenant().tenantId
+    sku: {
+      family: 'A'
+      name: 'standard'
+    }
+    enableRbacAuthorization: true
+    enableSoftDelete: true
+    softDeleteRetentionInDays: 7
+  }
+}
+
+resource connectionStringSecret 'Microsoft.KeyVault/vaults/secrets@2023-07-01' = {
+  parent: kv
+  name: connectionStringSecretName
+  properties: {
+    value: sqlConnectionString
+  }
+}
+
+// Grant the App Service managed identity read access to secrets
+resource kvSecretsUserRoleAssignment 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
+  scope: kv
+  name: guid(kv.id, appServicePrincipalId, kvSecretsUserRoleId)
+  properties: {
+    roleDefinitionId: subscriptionResourceId('Microsoft.Authorization/roleDefinitions', kvSecretsUserRoleId)
+    principalId: appServicePrincipalId
+    principalType: 'ServicePrincipal'
+  }
+}
+
+output vaultUri string = kv.properties.vaultUri

--- a/infra/bicep/modules/sql.bicep
+++ b/infra/bicep/modules/sql.bicep
@@ -1,0 +1,56 @@
+@description('Name of the Azure SQL logical server.')
+param serverName string
+
+@description('Name of the database.')
+param databaseName string
+
+param location string
+
+@description('SQL Server administrator login name.')
+param adminLogin string
+
+@description('SQL Server administrator login password.')
+@secure()
+param adminPassword string
+
+@description('Database SKU name, e.g. Basic, S0, S1.')
+param databaseSkuName string = 'Basic'
+
+@description('Database SKU tier.')
+param databaseSkuTier string = 'Basic'
+
+resource sqlServer 'Microsoft.Sql/servers@2023-08-01-preview' = {
+  name: serverName
+  location: location
+  properties: {
+    administratorLogin: adminLogin
+    administratorLoginPassword: adminPassword
+    minimalTlsVersion: '1.2'
+    publicNetworkAccess: 'Enabled'
+  }
+}
+
+// Allow Azure services to connect (required for App Service outbound traffic)
+resource allowAzureServices 'Microsoft.Sql/servers/firewallRules@2023-08-01-preview' = {
+  parent: sqlServer
+  name: 'AllowAllWindowsAzureIps'
+  properties: {
+    startIpAddress: '0.0.0.0'
+    endIpAddress: '0.0.0.0'
+  }
+}
+
+resource sqlDatabase 'Microsoft.Sql/servers/databases@2023-08-01-preview' = {
+  parent: sqlServer
+  name: databaseName
+  location: location
+  sku: {
+    name: databaseSkuName
+    tier: databaseSkuTier
+  }
+}
+
+output serverFqdn string = sqlServer.properties.fullyQualifiedDomainName
+
+@secure()
+output connectionString string = 'Server=tcp:${sqlServer.properties.fullyQualifiedDomainName},1433;Database=${databaseName};User Id=${adminLogin};Password=${adminPassword};Encrypt=True;TrustServerCertificate=False;Connection Timeout=30;'


### PR DESCRIPTION
## Summary

Implements the Phase 1 Bicep IaC skeleton for the exam-simulator cloud infrastructure (#5).

Creates a modular Bicep template that provisions all resources needed to host the application on Azure App Service with Azure SQL and Key Vault for secret management.


## What each module provisions

**`appservice.bicep`**
- Linux App Service Plan
- Web App (ASP.NET Core / .NET 10)
- System-assigned managed identity
- Connection string injected via Key Vault reference (`@Microsoft.KeyVault(...)`)
- HTTPS-only, TLS 1.2 minimum

**`sql.bicep`**
- Azure SQL logical server (TLS 1.2 minimum)
- SQL database
- Firewall rule allowing Azure services
- Admin password marked `@secure()`

**`keyvault.bicep`**
- Key Vault with RBAC authorization mode
- Secret `ConnectionStrings--DefaultConnection` populated from SQL output
- Key Vault Secrets User role assigned to the app's managed identity
- Soft-delete retention: 7 days

## Environment SKUs

| Resource | Staging | Prod |
|----------|---------|------|
| App Service Plan | F1 Free | B1 Basic (~$13/mo) |
| Azure SQL | Basic (5 DTU, 2 GB) | Basic (5 DTU, 2 GB) |
| Key Vault | Standard | Standard |
| **Est. monthly cost** | **~$6** | **~$19** |

## Security

- App never holds the SQL password directly — reads it from Key Vault at runtime via managed identity
- No secrets stored in `appsettings.json` or environment variables on the app
- SQL admin credentials supplied at deploy time via `readEnvironmentVariable` (CI secrets), never committed

## Validation

All 6 Bicep files pass the Bicep linter with zero diagnostics.