### PR TITLE
feat: add Exam Profiles and Take an Exam nav links (#23)

### DIFF
--- a/src/ExamSimulator.Web/Components/Layout/NavMenu.razor
+++ b/src/ExamSimulator.Web/Components/Layout/NavMenu.razor
@@ -15,8 +15,20 @@
         </div>
 
         <div class="nav-item px-3">
+            <NavLink class="nav-link" href="exams" Match="NavLinkMatch.Prefix">
+                <span class="bi bi-list-nested-nav-menu" aria-hidden="true"></span> Take an Exam
+            </NavLink>
+        </div>
+
+        <div class="nav-item px-3">
             <NavLink class="nav-link" href="questions" Match="NavLinkMatch.Prefix">
                 <span class="bi bi-question-circle-fill-nav-menu" aria-hidden="true"></span> Questions
+            </NavLink>
+        </div>
+
+        <div class="nav-item px-3">
+            <NavLink class="nav-link" href="exam-profiles" Match="NavLinkMatch.Prefix">
+                <span class="bi bi-list-nested-nav-menu" aria-hidden="true"></span> Exam Profiles
             </NavLink>
         </div>
 


### PR DESCRIPTION
## feat: add Exam Profiles and Take an Exam nav links (#23)

Closes #23

Adds two navigation links to the sidebar so users can reach the new pages without manually typing URLs.

### Changes

**`Components/Layout/NavMenu.razor`**
- Added **"Take an Exam"** → `/exams` (above Questions — learner-facing, highest priority)
- Added **"Exam Profiles"** → `/exam-profiles` (below Questions — admin section)

Both links use `NavLinkMatch.Prefix` so the active state highlights correctly when navigating to sub-pages (e.g. `/exams/az-204` or `/exam-profiles/create`).