### PR TITLE
feat: ordering question type and question randomisation (#29, #30)

### DIFF
--- a/src/ExamSimulator.Web/Domain/Questions/Question.cs
+++ b/src/ExamSimulator.Web/Domain/Questions/Question.cs
@@ -68,6 +68,9 @@ public sealed class Question
         if (type == QuestionType.SingleChoice && indexList.Count != 1)
             throw new ArgumentException("Single choice questions must have exactly one correct option.", nameof(correctOptionIndices));
 
+        if (type == QuestionType.Ordering && indexList.Count != optionList.Count)
+            throw new ArgumentException("Ordering questions must have one index per option (a full permutation).", nameof(correctOptionIndices));
+
         Id = id;
         ExamProfileId = examProfileId.Trim();
         Type = type;

--- a/src/ExamSimulator.Web/Domain/Questions/QuestionType.cs
+++ b/src/ExamSimulator.Web/Domain/Questions/QuestionType.cs
@@ -3,5 +3,6 @@ namespace ExamSimulator.Web.Domain.Questions;
 public enum QuestionType
 {
     SingleChoice = 0,
-    MultipleChoice = 1
+    MultipleChoice = 1,
+    Ordering = 2
 }

--- a/src/ExamSimulator.Web/Features/Exams/ExamSession.razor
+++ b/src/ExamSimulator.Web/Features/Exams/ExamSession.razor
@@ -42,6 +42,10 @@ else if (_state == SessionState.InProgress)
             {
                 <p class="text-muted fst-italic">Select all that apply.</p>
             }
+            else if (q.Type == QuestionType.Ordering)
+            {
+                <p class="text-muted fst-italic">Arrange the options in the correct order.</p>
+            }
 
             <div class="list-group mt-3">
                 @for (int i = 0; i < q.Options.Count; i++)
@@ -49,7 +53,19 @@ else if (_state == SessionState.InProgress)
                     var optionIndex = i;
                     var isSelected = _answers.TryGetValue(q.Id, out var sel) && sel.Contains(optionIndex);
 
-                    @if (q.Type == QuestionType.SingleChoice)
+                    @if (q.Type == QuestionType.Ordering)
+                    {
+                        var orderedAnswer = _answers.TryGetValue(q.Id, out var ord) ? ord : Enumerable.Range(0, q.Options.Count).ToList();
+                        var displayIndex = orderedAnswer[optionIndex];
+                        <div class="list-group-item d-flex align-items-center gap-2">
+                            <div class="d-flex flex-column">
+                                <button class="btn btn-sm btn-outline-secondary py-0" @onclick="() => MoveUp(q.Id, optionIndex)" disabled="@(optionIndex == 0)" title="Move up">↑</button>
+                                <button class="btn btn-sm btn-outline-secondary py-0" @onclick="() => MoveDown(q.Id, optionIndex)" disabled="@(optionIndex == q.Options.Count - 1)" title="Move down">↓</button>
+                            </div>
+                            <span>@q.Options[displayIndex]</span>
+                        </div>
+                    }
+                    else if (q.Type == QuestionType.SingleChoice)
                     {
                         <label class="list-group-item list-group-item-action @(isSelected ? "active" : "")">
                             <input type="radio"
@@ -108,7 +124,9 @@ else if (_state == SessionState.Submitted)
         var userSel = _answers.TryGetValue(q.Id, out var s) ? s : new List<int>();
         var correct = new HashSet<int>(q.CorrectOptionIndices);
         var userSet = new HashSet<int>(userSel);
-        var isCorrect = correct.SetEquals(userSet);
+        var isCorrect = q.Type == QuestionType.Ordering
+            ? q.CorrectOptionIndices.SequenceEqual(userSel)
+            : correct.SetEquals(userSet);
 
         <div class="card mb-3 border-@(isCorrect ? "success" : "danger")">
             <div class="card-header bg-@(isCorrect ? "success" : "danger") text-white">
@@ -117,16 +135,35 @@ else if (_state == SessionState.Submitted)
             <div class="card-body">
                 <p class="fw-bold">@q.Prompt</p>
                 <ul class="list-unstyled">
-                    @for (int oi = 0; oi < q.Options.Count; oi++)
+                    @if (q.Type == QuestionType.Ordering)
                     {
-                        var optIdx = oi;
-                        var wasSelected = userSet.Contains(optIdx);
-                        var isCorrectOpt = correct.Contains(optIdx);
+                        var userOrder = _answers.TryGetValue(q.Id, out var ord) ? ord : Enumerable.Range(0, q.Options.Count).ToList();
+                        @for (int oi = 0; oi < q.Options.Count; oi++)
+                        {
+                            var pos = oi;
+                            var displayedOptionIdx = userOrder[pos];
+                            var correctAtPos = q.CorrectOptionIndices[pos];
+                            var placedCorrectly = displayedOptionIdx == correctAtPos;
+                            <li class="@(placedCorrectly ? "text-success fw-semibold" : "text-danger")">
+                                @(pos + 1). @q.Options[displayedOptionIdx]
+                                @if (placedCorrectly) { <span class="ms-1">✓</span> }
+                                else { <span class="ms-1 text-muted fst-italic">(expected: @q.Options[correctAtPos])</span> }
+                            </li>
+                        }
+                    }
+                    else
+                    {
+                        @for (int oi = 0; oi < q.Options.Count; oi++)
+                        {
+                            var optIdx = oi;
+                            var wasSelected = userSet.Contains(optIdx);
+                            var isCorrectOpt = correct.Contains(optIdx);
 
-                        <li class="@(isCorrectOpt ? "text-success fw-semibold" : wasSelected ? "text-danger text-decoration-line-through" : "")">
-                            @(wasSelected ? "☑" : "☐") @q.Options[optIdx]
-                            @if (isCorrectOpt) { <span class="ms-1">✓</span> }
-                        </li>
+                            <li class="@(isCorrectOpt ? "text-success fw-semibold" : wasSelected ? "text-danger text-decoration-line-through" : "")">
+                                @(wasSelected ? "☑" : "☐") @q.Options[optIdx]
+                                @if (isCorrectOpt) { <span class="ms-1">✓</span> }
+                            </li>
+                        }
                     }
                 </ul>
                 @if (q.Explanation is not null)
@@ -177,6 +214,11 @@ else if (_state == SessionState.Submitted)
             return;
         }
 
+        _questions = _questions.OrderBy(_ => Random.Shared.Next()).ToList();
+
+        foreach (var q in _questions.Where(q => q.Type == QuestionType.Ordering))
+            _answers[q.Id] = Enumerable.Range(0, q.Options.Count).OrderBy(_ => Random.Shared.Next()).ToList();
+
         _state = SessionState.InProgress;
     }
 
@@ -203,15 +245,35 @@ else if (_state == SessionState.Submitted)
 
     private void Prev() => _currentIndex--;
 
+    private void MoveUp(Guid questionId, int position)
+    {
+        if (!_answers.TryGetValue(questionId, out var order) || position <= 0) return;
+        (order[position - 1], order[position]) = (order[position], order[position - 1]);
+    }
+
+    private void MoveDown(Guid questionId, int position)
+    {
+        if (!_answers.TryGetValue(questionId, out var order) || position >= order.Count - 1) return;
+        (order[position], order[position + 1]) = (order[position + 1], order[position]);
+    }
+
     private void Submit()
     {
         _score = 0;
         foreach (var q in _questions)
         {
             var userSel = _answers.TryGetValue(q.Id, out var s) ? s : new List<int>();
-            var correct = new HashSet<int>(q.CorrectOptionIndices);
-            if (correct.SetEquals(new HashSet<int>(userSel)))
-                _score++;
+            if (q.Type == QuestionType.Ordering)
+            {
+                if (q.CorrectOptionIndices.SequenceEqual(userSel))
+                    _score++;
+            }
+            else
+            {
+                var correct = new HashSet<int>(q.CorrectOptionIndices);
+                if (correct.SetEquals(new HashSet<int>(userSel)))
+                    _score++;
+            }
         }
         _state = SessionState.Submitted;
     }

--- a/src/ExamSimulator.Web/Features/Questions/CreateQuestion.razor
+++ b/src/ExamSimulator.Web/Features/Questions/CreateQuestion.razor
@@ -40,6 +40,12 @@
                        @onchange="() => SetType(QuestionType.MultipleChoice)" />
                 <label class="form-check-label" for="typeMultiple">Multiple Choice</label>
             </div>
+            <div class="form-check form-check-inline">
+                <input class="form-check-input" type="radio" id="typeOrdering" name="questionType"
+                       checked="@(_model.Type == QuestionType.Ordering)"
+                       @onchange="() => SetType(QuestionType.Ordering)" />
+                <label class="form-check-label" for="typeOrdering">Ordering</label>
+            </div>
         </div>
     </div>
 
@@ -71,31 +77,43 @@
             {
                 <small class="text-muted ms-1">(select the correct answer)</small>
             }
-            else
+            else if (_model.Type == QuestionType.MultipleChoice)
             {
                 <small class="text-muted ms-1">(select all correct answers)</small>
+            }
+            else
+            {
+                <small class="text-muted ms-1">(arrange options in the correct order)</small>
             }
         </label>
         @for (int i = 0; i < _model.Options.Count; i++)
         {
             var index = i;
             <div class="input-group mb-2">
-                <div class="input-group-text">
-                    @if (_model.Type == QuestionType.SingleChoice)
-                    {
-                        <input type="radio" name="correctOption"
-                               checked="@(_model.CorrectOptionIndex == index)"
-                               @onchange="() => _model.CorrectOptionIndex = index"
-                               title="Mark as correct" />
-                    }
-                    else
-                    {
-                        <input type="checkbox"
-                               checked="@_model.SelectedIndices.Contains(index)"
-                               @onchange="e => ToggleIndex(index, (bool)e.Value!)"
-                               title="Mark as correct" />
-                    }
-                </div>
+                @if (_model.Type == QuestionType.Ordering)
+                {
+                    <button type="button" class="btn btn-outline-secondary" @onclick="() => MoveOptionUp(index)" disabled="@(index == 0)" title="Move up">↑</button>
+                    <button type="button" class="btn btn-outline-secondary" @onclick="() => MoveOptionDown(index)" disabled="@(index == _model.Options.Count - 1)" title="Move down">↓</button>
+                }
+                else
+                {
+                    <div class="input-group-text">
+                        @if (_model.Type == QuestionType.SingleChoice)
+                        {
+                            <input type="radio" name="correctOption"
+                                   checked="@(_model.CorrectOptionIndex == index)"
+                                   @onchange="() => _model.CorrectOptionIndex = index"
+                                   title="Mark as correct" />
+                        }
+                        else
+                        {
+                            <input type="checkbox"
+                                   checked="@_model.SelectedIndices.Contains(index)"
+                                   @onchange="e => ToggleIndex(index, (bool)e.Value!)"
+                                   title="Mark as correct" />
+                        }
+                    </div>
+                }
                 <input type="text" class="form-control" value="@_model.Options[index]"
                        @oninput="e => _model.Options[index] = e.Value?.ToString() ?? string.Empty"
                        placeholder="Option @(index + 1)" />
@@ -162,6 +180,18 @@
             _model.SelectedIndices.Remove(index);
     }
 
+    private void MoveOptionUp(int index)
+    {
+        if (index <= 0) return;
+        (_model.Options[index - 1], _model.Options[index]) = (_model.Options[index], _model.Options[index - 1]);
+    }
+
+    private void MoveOptionDown(int index)
+    {
+        if (index >= _model.Options.Count - 1) return;
+        (_model.Options[index], _model.Options[index + 1]) = (_model.Options[index + 1], _model.Options[index]);
+    }
+
     private async Task HandleSubmit()
     {
         _errorMessage = null;
@@ -169,7 +199,9 @@
         {
             IEnumerable<int> correctIndices = _model.Type == QuestionType.SingleChoice
                 ? [_model.CorrectOptionIndex]
-                : _model.SelectedIndices.Order();
+                : _model.Type == QuestionType.Ordering
+                    ? Enumerable.Range(0, _model.Options.Count)
+                    : _model.SelectedIndices.Order();
 
             var question = new Question(
                 Guid.NewGuid(),

--- a/src/ExamSimulator.Web/Features/Questions/EditQuestion.razor
+++ b/src/ExamSimulator.Web/Features/Questions/EditQuestion.razor
@@ -47,6 +47,12 @@ else if (_model is not null)
                            @onchange="() => SetType(QuestionType.MultipleChoice)" />
                     <label class="form-check-label" for="typeMultiple">Multiple Choice</label>
                 </div>
+                <div class="form-check form-check-inline">
+                    <input class="form-check-input" type="radio" id="typeOrdering" name="questionType"
+                           checked="@(_model.Type == QuestionType.Ordering)"
+                           @onchange="() => SetType(QuestionType.Ordering)" />
+                    <label class="form-check-label" for="typeOrdering">Ordering</label>
+                </div>
             </div>
         </div>
 
@@ -78,31 +84,43 @@ else if (_model is not null)
                 {
                     <small class="text-muted ms-1">(select the correct answer)</small>
                 }
-                else
+                else if (_model.Type == QuestionType.MultipleChoice)
                 {
                     <small class="text-muted ms-1">(select all correct answers)</small>
+                }
+                else
+                {
+                    <small class="text-muted ms-1">(arrange options in the correct order)</small>
                 }
             </label>
             @for (int i = 0; i < _model.Options.Count; i++)
             {
                 var index = i;
                 <div class="input-group mb-2">
-                    <div class="input-group-text">
-                        @if (_model.Type == QuestionType.SingleChoice)
-                        {
-                            <input type="radio" name="correctOption"
-                                   checked="@(_model.CorrectOptionIndex == index)"
-                                   @onchange="() => _model.CorrectOptionIndex = index"
-                                   title="Mark as correct" />
-                        }
-                        else
-                        {
-                            <input type="checkbox"
-                                   checked="@_model.SelectedIndices.Contains(index)"
-                                   @onchange="e => ToggleIndex(index, (bool)e.Value!)"
-                                   title="Mark as correct" />
-                        }
-                    </div>
+                    @if (_model.Type == QuestionType.Ordering)
+                    {
+                        <button type="button" class="btn btn-outline-secondary" @onclick="() => MoveOptionUp(index)" disabled="@(index == 0)" title="Move up">↑</button>
+                        <button type="button" class="btn btn-outline-secondary" @onclick="() => MoveOptionDown(index)" disabled="@(index == _model.Options.Count - 1)" title="Move down">↓</button>
+                    }
+                    else
+                    {
+                        <div class="input-group-text">
+                            @if (_model.Type == QuestionType.SingleChoice)
+                            {
+                                <input type="radio" name="correctOption"
+                                       checked="@(_model.CorrectOptionIndex == index)"
+                                       @onchange="() => _model.CorrectOptionIndex = index"
+                                       title="Mark as correct" />
+                            }
+                            else
+                            {
+                                <input type="checkbox"
+                                       checked="@_model.SelectedIndices.Contains(index)"
+                                       @onchange="e => ToggleIndex(index, (bool)e.Value!)"
+                                       title="Mark as correct" />
+                            }
+                        </div>
+                    }
                     <input type="text" class="form-control" value="@_model.Options[index]"
                            @oninput="e => _model.Options[index] = e.Value?.ToString() ?? string.Empty"
                            placeholder="Option @(index + 1)" />
@@ -164,7 +182,7 @@ else if (_model is not null)
         {
             _model.CorrectOptionIndex = question.CorrectOptionIndices[0];
         }
-        else
+        else if (question.Type != QuestionType.Ordering)
         {
             _model.SelectedIndices = [.. question.CorrectOptionIndices];
         }
@@ -200,6 +218,18 @@ else if (_model is not null)
             _model!.SelectedIndices.Remove(index);
     }
 
+    private void MoveOptionUp(int index)
+    {
+        if (index <= 0) return;
+        (_model!.Options[index - 1], _model.Options[index]) = (_model.Options[index], _model.Options[index - 1]);
+    }
+
+    private void MoveOptionDown(int index)
+    {
+        if (index >= _model!.Options.Count - 1) return;
+        (_model.Options[index], _model.Options[index + 1]) = (_model.Options[index + 1], _model.Options[index]);
+    }
+
     private async Task HandleSubmit()
     {
         _errorMessage = null;
@@ -207,7 +237,9 @@ else if (_model is not null)
         {
             IEnumerable<int> correctIndices = _model!.Type == QuestionType.SingleChoice
                 ? [_model.CorrectOptionIndex]
-                : _model.SelectedIndices.Order();
+                : _model.Type == QuestionType.Ordering
+                    ? Enumerable.Range(0, _model.Options.Count)
+                    : _model.SelectedIndices.Order();
 
             var updated = new Question(
                 Id,

--- a/tests/ExamSimulator.Web.UnitTests/Questions/QuestionTests.cs
+++ b/tests/ExamSimulator.Web.UnitTests/Questions/QuestionTests.cs
@@ -169,6 +169,61 @@ public class QuestionTests
         Assert.Equal("correctOptionIndices", ex.ParamName);
     }
 
+    // ── ordering invariants ───────────────────────────────────────────────────
+
+    private static Question Ordering(string[]? options = null, int[]? correctIndices = null)
+    {
+        var opts = options ?? ["First", "Second", "Third", "Fourth"];
+        var idx = correctIndices ?? Enumerable.Range(0, opts.Length).ToArray();
+        return new(Guid.NewGuid(), "az-204", QuestionType.Ordering, Difficulty.Medium,
+            "Arrange in order", opts, idx, "ordering");
+    }
+
+    [Fact]
+    public void Constructor_Ordering_WithFullPermutation_CreatesQuestion()
+    {
+        var question = Ordering(correctIndices: [3, 0, 2, 1]);
+
+        Assert.Equal(QuestionType.Ordering, question.Type);
+        Assert.Equal([3, 0, 2, 1], question.CorrectOptionIndices);
+    }
+
+    [Fact]
+    public void Constructor_Ordering_WithFewerIndicesThanOptions_ThrowsArgumentException()
+    {
+        var ex = Assert.Throws<ArgumentException>(() =>
+            Ordering(correctIndices: [0, 1, 2])); // 4 options, only 3 indices
+
+        Assert.Equal("correctOptionIndices", ex.ParamName);
+    }
+
+    [Fact]
+    public void Constructor_Ordering_WithMoreIndicesThanOptions_ThrowsArgumentException()
+    {
+        var ex = Assert.Throws<ArgumentException>(() =>
+            Ordering(options: ["A", "B", "C"], correctIndices: [0, 1, 2, 0])); // 3 options, 4 indices
+
+        Assert.Equal("correctOptionIndices", ex.ParamName);
+    }
+
+    [Fact]
+    public void Constructor_Ordering_WithDuplicateIndices_ThrowsArgumentException()
+    {
+        var ex = Assert.Throws<ArgumentException>(() =>
+            Ordering(options: ["A", "B", "C"], correctIndices: [0, 0, 2]));
+
+        Assert.Equal("correctOptionIndices", ex.ParamName);
+    }
+
+    [Fact]
+    public void Constructor_Ordering_WithOutOfRangeIndex_ThrowsArgumentOutOfRangeException()
+    {
+        var ex = Assert.Throws<ArgumentOutOfRangeException>(() =>
+            Ordering(options: ["A", "B", "C"], correctIndices: [0, 1, 5]));
+
+        Assert.Equal("correctOptionIndices", ex.ParamName);
+    }
+
     // ── shared option/prompt invariants ───────────────────────────────────────
 
     [Fact]


### PR DESCRIPTION
## Summary

Implements issues #29 (Ordering question type) and #30 (Question randomisation).

## Changes

### Domain
- `QuestionType.cs` — added `Ordering = 2` enum value
- `Question.cs` — Ordering invariant validation: `CorrectOptionIndices` must be a valid permutation of `[0, Options.Count)` (correct count, all distinct, all in range)

### Admin UI
- `CreateQuestion.razor` / `EditQuestion.razor` — Ordering type support with Up/Down buttons to reorder options (entry order = correct order); no "correct" checkboxes shown

### Exam Session
- `ExamSession.razor`:
  - Renders Ordering questions as a reorderable list with Up/Down buttons
  - Scores Ordering answers using `SequenceEqual` (order matters)
  - Initial Ordering answer permutation is shuffled (options start in random order)
  - Question list is randomised on each session start using `Random.Shared`

### Tests
- `QuestionTests.cs` — unit tests for Ordering invariants (valid permutation, wrong count, duplicate index, out-of-range index)

## Closes
- #29 — Ordering question type
- #30 — Randomise question order per session