### PR TITLE
feat: allow repeated matching targets - pool semantics for Matching t…

### DIFF
--- a/docs/iteration-7-plan.md
+++ b/docs/iteration-7-plan.md
@@ -55,7 +55,7 @@ The import file is a single JSON object with a top-level `examProfileId` string 
 | `questions[].correctOptionIndices` | Yes (except `Ordering`, `Matching`) | Valid indices into `options` |
 | `questions[].topicTag` | No | Optional tag string |
 | `questions[].explanation` | No | Optional markdown explanation |
-| `questions[].matchingTargets` | Only for `Matching` | List of strings matching 1-to-1 with `options` |
+| `questions[].matchingTargets` | Only for `Matching` | Pool of ≥ 2 target strings; each premise selects from this pool via dropdown; the same target may appear in multiple correct pairings |
 
 ### Deduplication Strategy
 

--- a/docs/question-import-format.md
+++ b/docs/question-import-format.md
@@ -124,22 +124,22 @@ The learner selects a subset of options and places them in order.
 
 ### `Matching`
 
-The learner pairs each premise (left column) with a target (right column).
+The learner pairs each premise (left column) with a target (right column) using a dropdown per premise. The same target may be selected for multiple premises (repetition is allowed), so the targets act as a pool rather than a 1-to-1 set.
 
 - `options`: the **premises** (left column)
-- `matchingTargets`: the **targets** (right column); must contain **at least as many entries as options**; all must be non-empty
-- `correctOptionIndices`: one index per premise — `correctOptionIndices[i]` is the 0-based index into `matchingTargets` that premise `i` pairs with
+- `matchingTargets`: the **pool of targets** (right column); must contain **at least 2 entries**; all must be non-empty; may contain more or fewer entries than `options`
+- `correctOptionIndices`: one index per premise — `correctOptionIndices[i]` is the 0-based index into `matchingTargets` that premise `i` pairs with; the same index may appear multiple times (repetition)
 
 ```json
 {
   "type": "Matching",
-  "options": ["Premise 1", "Premise 2"],
-  "matchingTargets": ["Target A", "Target B", "Target C"],
-  "correctOptionIndices": [2, 0]
+  "options": ["Premise 1", "Premise 2", "Premise 3"],
+  "matchingTargets": ["Target A", "Target B"],
+  "correctOptionIndices": [1, 0, 1]
 }
 ```
 
-The example pairs Premise 1 → Target C, Premise 2 → Target A.
+The example pairs Premise 1 → Target B, Premise 2 → Target A, Premise 3 → Target B (Target B used twice).
 
 ---
 

--- a/src/ExamSimulator.Web/Domain/Questions/Question.cs
+++ b/src/ExamSimulator.Web/Domain/Questions/Question.cs
@@ -65,7 +65,7 @@ public sealed class Question
         if (indexList.Any(i => i < 0 || i >= optionList.Count))
             throw new ArgumentOutOfRangeException(nameof(correctOptionIndices), "All correct option indices must be within the options range.");
 
-        if (indexList.Distinct().Count() != indexList.Count)
+        if (type != QuestionType.Matching && indexList.Distinct().Count() != indexList.Count)
             throw new ArgumentException("Correct option indices must be unique.", nameof(correctOptionIndices));
 
         if (type == QuestionType.SingleChoice && indexList.Count != 1)
@@ -87,8 +87,8 @@ public sealed class Question
             if (matchingTargets is null)
                 throw new ArgumentNullException(nameof(matchingTargets), "Matching questions require matching targets.");
             var targetList = matchingTargets.ToList();
-            if (targetList.Count < optionList.Count)
-                throw new ArgumentException("Matching targets must have at least as many entries as premises.", nameof(matchingTargets));
+            if (targetList.Count < 2)
+                throw new ArgumentException("Matching questions must have at least 2 targets.", nameof(matchingTargets));
             if (targetList.Any(string.IsNullOrWhiteSpace))
                 throw new ArgumentException("Each matching target must contain text.", nameof(matchingTargets));
             if (indexList.Count != optionList.Count)

--- a/src/ExamSimulator.Web/Features/Questions/Import/QuestionImportValidator.cs
+++ b/src/ExamSimulator.Web/Features/Questions/Import/QuestionImportValidator.cs
@@ -113,8 +113,8 @@ public sealed class QuestionImportValidator
             return;
         }
 
-        if (item.MatchingTargets.Count < item.Options!.Count)
-            errors.Add("Matching: matchingTargets must have at least as many entries as options (premises).");
+        if (item.MatchingTargets.Count < 2)
+            errors.Add("Matching: at least 2 matching targets are required.");
 
         if (item.MatchingTargets.Any(string.IsNullOrWhiteSpace))
             errors.Add("Matching: each matching target must contain text.");

--- a/tests/ExamSimulator.Web.UnitTests/Questions/QuestionImportValidatorTests.cs
+++ b/tests/ExamSimulator.Web.UnitTests/Questions/QuestionImportValidatorTests.cs
@@ -149,7 +149,7 @@ public class QuestionImportValidatorTests
     [Fact]
     public void Validate_MatchingWithMismatchedTargetCount_ReturnsError()
     {
-        // 3 options but only 1 target
+        // Only 1 target — at least 2 are required
         var item = MatchingItem(
             options: ["A", "B", "C"],
             targets: ["TargetA"],
@@ -157,7 +157,21 @@ public class QuestionImportValidatorTests
 
         var errors = _validator.Validate(item);
 
-        Assert.Contains(errors, e => e.Contains("matchingTargets") && e.Contains("at least as many"));
+        Assert.Contains(errors, e => e.Contains("Matching") && e.Contains("at least 2"));
+    }
+
+    [Fact]
+    public void Validate_MatchingWithFewerTargetsThanPremises_ReturnsNoErrors()
+    {
+        // 3 premises, 2 targets with repeated index — valid
+        var item = MatchingItem(
+            options: ["A", "B", "C"],
+            targets: ["T1", "T2"],
+            correctIndices: [0, 1, 0]);
+
+        var errors = _validator.Validate(item);
+
+        Assert.Empty(errors);
     }
 
     [Fact]

--- a/tests/ExamSimulator.Web.UnitTests/Questions/QuestionTests.cs
+++ b/tests/ExamSimulator.Web.UnitTests/Questions/QuestionTests.cs
@@ -388,12 +388,23 @@ public class QuestionTests
     }
 
     [Fact]
-    public void Constructor_Matching_WithFewerTargetsThanPremises_ThrowsArgumentException()
+    public void Constructor_Matching_WithOnlyOneTarget_ThrowsArgumentException()
     {
         var ex = Assert.Throws<ArgumentException>(() =>
-            Matching(options: ["P1", "P2", "P3"], matchingTargets: ["T1", "T2"], correctIndices: [0, 1, 2]));
+            Matching(options: ["P1", "P2", "P3"], matchingTargets: ["T1"], correctIndices: [0, 0, 0]));
 
         Assert.Equal("matchingTargets", ex.ParamName);
+    }
+
+    [Fact]
+    public void Constructor_Matching_WithFewerTargetsThanPremises_CreatesQuestion()
+    {
+        // 3 premises, 2 targets — valid because repetition is allowed
+        var question = Matching(options: ["P1", "P2", "P3"], matchingTargets: ["T1", "T2"], correctIndices: [0, 1, 0]);
+
+        Assert.Equal(3, question.Options.Count);
+        Assert.Equal(2, question.MatchingTargets!.Count);
+        Assert.Equal([0, 1, 0], question.CorrectOptionIndices);
     }
 
     [Fact]
@@ -424,11 +435,11 @@ public class QuestionTests
     }
 
     [Fact]
-    public void Constructor_Matching_WithDuplicatePairingIndex_ThrowsArgumentException()
+    public void Constructor_Matching_WithRepeatedPairingIndices_CreatesQuestion()
     {
-        var ex = Assert.Throws<ArgumentException>(() =>
-            Matching(correctIndices: [0, 0, 2])); // T0 matched to both P1 and P2
+        // Multiple premises can map to the same target (repetition allowed)
+        var question = Matching(correctIndices: [0, 0, 2]);
 
-        Assert.Equal("correctOptionIndices", ex.ParamName);
+        Assert.Equal([0, 0, 2], question.CorrectOptionIndices);
     }
 }


### PR DESCRIPTION
## Summary

Relaxes the `Matching` question type so that `matchingTargets` acts as a **pool** — multiple premises can map to the same target. The previous constraint enforced 1-to-1 mapping, making it impossible to model real exam questions where the same answer applies to more than one premise.

## Changes

### Domain — `src/ExamSimulator.Web/Domain/Questions/Question.cs`
- `correctOptionIndices` uniqueness check now skips `Matching` (repeated indices are valid)
- `matchingTargets` minimum count reduced from `>= premises` to `>= 2`

### Validator — `src/ExamSimulator.Web/Features/Questions/Import/QuestionImportValidator.cs`
- Same `>= 2` minimum applied for imported `matchingTargets`

### Tests — `tests/ExamSimulator.Web.UnitTests/`
- `QuestionTests.cs`: `WithFewerTargetsThanPremises` → now tests the `< 2` rejection; new `WithRepeatedPairingIndices_CreatesQuestion` positive test
- `QuestionImportValidatorTests.cs`: updated error assertion; added `Validate_MatchingWithFewerTargetsThanPremises_ReturnsNoErrors`

### Docs
- `docs/question-import-format.md`: Matching section rewritten with pool semantics and repetition example
- `docs/iteration-7-plan.md`: schema table row for `matchingTargets` updated

## No UI changes

The exam session already renders a dropdown per premise from the full `matchingTargets` list with no exclusion logic — repetition already worked at runtime.

## Test results

102 tests passing (was 100 before this change added 2 new tests).

Closes #58