### PR TITLE
feat: use Guid.CreateVersion7() for stable insertion-order sorting (closes #86)

### DIFF
--- a/src/ExamSimulator.Web/Features/Exams/ExamSession.razor
+++ b/src/ExamSimulator.Web/Features/Exams/ExamSession.razor
@@ -599,7 +599,7 @@ else if (_state == SessionState.Submitted)
             var userId = authState.User.FindFirstValue(ClaimTypes.NameIdentifier);
             if (userId is not null)
             {
-                var attemptId = Guid.NewGuid();
+                var attemptId = Guid.CreateVersion7();
                 var attempt = new ExamAttempt(
                     attemptId,
                     userId,
@@ -629,7 +629,7 @@ else if (_state == SessionState.Submitted)
                             selectedOptionIndices = sel;
                         }
                     }
-                    DbContext.ExamAttemptAnswers.Add(new ExamAttemptAnswer(Guid.NewGuid(), attemptId, q.Id, isCorrect, selectedOptionIndices));
+                    DbContext.ExamAttemptAnswers.Add(new ExamAttemptAnswer(Guid.CreateVersion7(), attemptId, q.Id, isCorrect, selectedOptionIndices));
                 }
                 await DbContext.SaveChangesAsync();
                 _lastAttemptId = attemptId;

--- a/src/ExamSimulator.Web/Features/Questions/CreateQuestion.razor
+++ b/src/ExamSimulator.Web/Features/Questions/CreateQuestion.razor
@@ -379,7 +379,7 @@
                 correctIndices = _model.SelectedIndices.Order();
 
             var question = new Question(
-                Guid.NewGuid(),
+                Guid.CreateVersion7(),
                 _model.ExamProfileId,
                 _model.Type,
                 _model.Difficulty,

--- a/src/ExamSimulator.Web/Features/Questions/Import/QuestionImportService.cs
+++ b/src/ExamSimulator.Web/Features/Questions/Import/QuestionImportService.cs
@@ -102,7 +102,7 @@ public sealed class QuestionImportService(
         var toInsert = preview.Items
             .Where(i => i.Status == ImportItemStatus.Valid)
             .Select(i => new Question(
-                i.Item.Id ?? Guid.NewGuid(),
+                i.Item.Id ?? Guid.CreateVersion7(),
                 preview.ExamProfileId,
                 i.Item.Type,
                 i.Item.Difficulty,

--- a/src/ExamSimulator.Web/Features/Questions/ListQuestions.razor
+++ b/src/ExamSimulator.Web/Features/Questions/ListQuestions.razor
@@ -167,7 +167,7 @@ else
             query = query.Where(q => q.Difficulty == diff);
         _totalCount = await query.CountAsync();
         _questions = await query
-            .OrderBy(q => q.ExamProfileId).ThenBy(q => q.TopicTag).ThenBy(q => q.Id)
+            .OrderBy(q => q.Id)
             .Skip((_page - 1) * PageSize)
             .Take(PageSize)
             .ToListAsync();


### PR DESCRIPTION
## Summary

- `CreateQuestion.razor` — `Guid.NewGuid()` → `Guid.CreateVersion7()` for new question Id
- `ExamSession.razor` — `Guid.CreateVersion7()` for `attemptId` and `ExamAttemptAnswer` Id
- `QuestionImportService.cs` — `Guid.CreateVersion7()` as fallback when import item has no explicit Id
- `ListQuestions.razor` — sort changed from `OrderBy(ExamProfileId).ThenBy(TopicTag).ThenBy(Id)` to `OrderBy(Id)` only
- `DbSeeder.cs` — unchanged (dev seed data, order irrelevant)

## Why

`Guid.CreateVersion7()` embeds a millisecond timestamp in the high bits (UUIDv7 spec), making GUIDs lexicographically ordered by creation time. Sorting the question list by `Id` now reflects insertion order — matching the order questions appear in the import file.

Import files with explicit GUIDs are unaffected; client-provided Ids continue to be preserved as-is.

## Validation

- [x] `dotnet build ExamSimulator.slnx` — 0 errors, 0 warnings
- [x] `dotnet test ExamSimulator.slnx` — 131 tests passed (102 unit + 29 functional)

## Notes

Existing questions with random V4 GUIDs will sort before all new V7 GUIDs (V4 high bits are random, V7 high bits are timestamp — current timestamp > most random values). A reimport is needed to see correct ordering for the existing 469 questions.

Closes #86